### PR TITLE
fix: suppress health check debug log spam in production

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,10 +3,11 @@
   "isRoot": true,
   "tools": {
     "paket": {
-      "version": "10.0.0-alpha011",
+      "version": "10.3.1",
       "commands": [
         "paket"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }

--- a/src/DLQService/Program.fs
+++ b/src/DLQService/Program.fs
@@ -83,7 +83,7 @@ let main args =
     let env = builder.Environment.EnvironmentName
     if env = "Production" then
         config.AddTarget(jsonTarget)
-        config.AddRuleForAllLevels(jsonTarget)
+        config.AddRule(LogLevel.Info, LogLevel.Fatal, jsonTarget)
         LogManager.Configuration <- config
     else
         config.AddTarget(devTarget)
@@ -92,7 +92,8 @@ let main args =
 
     // NOTE: Don't clear providers! ServiceDefaults added OpenTelemetry logging for Aspire Dashboard.
     // Just add NLog alongside it.
-    builder.Logging.SetMinimumLevel(LogLevel.Trace) |> ignore
+    let minLogLevel = if env = "Production" then LogLevel.Information else LogLevel.Debug
+    builder.Logging.SetMinimumLevel(minLogLevel) |> ignore
     // Reduce noisy DEBUG shutdown logs from NATS internals
     builder.Logging.AddFilter("NATS.Client.Core.Internal.NatsReadProtocolProcessor", LogLevel.Information) |> ignore
     builder.Logging.AddFilter("NATS.Client.Core.NatsConnection", LogLevel.Information) |> ignore
@@ -100,7 +101,8 @@ let main args =
     // Suppress health check Debug logs in production (they run every 5-30 seconds)
     builder.Logging.AddFilter("Mercator.HealthChecks.ServiceHealthCheck", LogLevel.Information) |> ignore
     builder.Logging.AddFilter("Mercator.HealthChecks.LivenessHealthCheck", LogLevel.Information) |> ignore
-    builder.Logging.AddNLog() |> ignore
+    builder.Logging.AddFilter("Microsoft.Extensions.Diagnostics.HealthChecks", LogLevel.Warning) |> ignore
+    builder.Logging.AddNLog(NLogProviderOptions(RemoveLoggerFactoryFilter = false)) |> ignore
 
     // Register services
     builder.Services.AddSingleton<INatsClient, NatsClient> configureNats |> ignore


### PR DESCRIPTION
## Changes

### Logging Fix
- `AddNLog()` now uses `RemoveLoggerFactoryFilter = false` so MEL filters are respected
  (previously defaulted to `true`, bypassing all filters including health check suppression)
- Production NLog rule changed from `AddRuleForAllLevels` to `Info→Fatal` (no debug output)
- MEL minimum level: `Information` in production, `Debug` in development
- Added filter for `Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService` → Warning
  (this was the main source of the 5-second debug log spam)